### PR TITLE
DP-014: add replay CLI and filtered log replay

### DIFF
--- a/diagpack/can/socketcan.py
+++ b/diagpack/can/socketcan.py
@@ -1,7 +1,7 @@
 
 """
  @file socketcan.py
- @brief Ouvrir une interface socket
+ @brief Outils pour interagir avec les interfaces SocketCAN sous Linux
  @copyright
  © 2025 SYLORIA — MIT License — BAQUEY Lucas (contact@syloria.fr)
 """
@@ -9,6 +9,7 @@
 import socket
 import struct
 
+CAN_MAX_DLEN = 8
 CAN_FRAME_FORMAT = "=IB3x8s" # 4 + 1 + 3 + 8 = 16 octets
 CAN_FRAME_SIZE = struct.calcsize(CAN_FRAME_FORMAT)
 
@@ -39,3 +40,35 @@ def read_frame(can_socket: socket.socket) -> tuple [int, int, bytes]:
     can_id, dlc, data = struct.unpack(CAN_FRAME_FORMAT, frame)
 
     return can_id, dlc, data[:dlc]
+
+def send_frame(can_socket: socket.socket, can_id: int, can_dlc: int, data: bytes) -> None :
+    if can_socket is None :
+        raise RuntimeError(
+            f"Socket CAN interface is not initialized"
+        )
+    
+    if not (0 <= can_dlc <= CAN_MAX_DLEN):
+        raise ValueError(f"CAN DLC must be in range 0 to {CAN_MAX_DLEN}")
+    
+    if len(data) != can_dlc:
+        raise ValueError(
+            f"Data length {len(data)} does not match DLC {can_dlc}"
+        )
+
+    # Pack l'ID and data in CAN format
+    pad_data = data.ljust(8, b"\x00") # Pad data to 8 bytes if necessary
+    frame = struct.pack(CAN_FRAME_FORMAT, can_id, can_dlc, pad_data)
+
+    # Send frame
+    try :
+        can_socket.send(frame)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Failed to send CAN frame: ID={can_id}, DLC={can_dlc}, Data={data.hex()}"
+        ) from exc
+
+
+
+    
+
+

--- a/diagpack/cli/app_cli.py
+++ b/diagpack/cli/app_cli.py
@@ -1,41 +1,93 @@
 """
- @file app_cli.py
- @brief Fournir une interface CLI (terminale)
- @copyright
- © 2025 SYLORIA — MIT License — BAQUEY Lucas (contact@syloria.fr)
+@file app_cli.py
+@brief Fournit une interface CLI terminale pour DiagPack CAN
+@copyright
+© 2025 SYLORIA — MIT License — BAQUEY Lucas (contact@syloria.fr)
 """
 
 import argparse
+
 from diagpack.can.socketcan import open_can_socket
 from diagpack.capture.capture_loop import run_capture_loop
+from diagpack.replay.replay_engine import replay_log
 
-# Create command-line interfaces with multiple subcommands
-def build_parfser() -> argparse.ArgumentParser:
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="diagpack",
-        description = "DiagPack CAN - Linux/SocketCAN diagnostic toolbox"
+        description="DiagPack CAN - Linux/SocketCAN diagnostic toolbox",
     )
 
-    subparsers = parser.add_subparsers(dest="command", required = True)
+    subparsers = parser.add_subparsers(dest="command", required=True)
 
+    # Capture command
     capture_parser = subparsers.add_parser(
-        "capture",   # Allows to capture CAN frame
-        help = "Capture CAN frames from a SocketCAN interface"
+        "capture",
+        help="Capture CAN frames from a SocketCAN interface",
     )
 
     capture_parser.add_argument(
         "--iface",
-        required = True,
-        help = "SocketCAN interface name as 'vcan0'"
+        required=True,
+        help="SocketCAN interface name, for example vcan0",
     )
 
     capture_parser.add_argument(
         "--output",
-        required = True,
-        help = "Output JSON line"
+        required=True,
+        help="Output JSONL file path",
+    )
+
+    # Replay command
+    replay_parser = subparsers.add_parser(
+        "replay",
+        help="Replay CAN frame events from a JSONL file",
+    )
+
+    replay_parser.add_argument(
+        "--iface",
+        required=True,
+        help="SocketCAN interface name. For example : vcan0",
+    )
+
+    replay_parser.add_argument(
+        "--file",
+        required=True,
+        help="Input JSONL log file path",
+    )
+
+    replay_parser.add_argument(
+        "--id",
+        dest="id_filter",
+        type=int,
+        nargs="*",
+        default=None,
+        help="Optional CAN ID filter (one or more IDs)",
+    )
+
+    replay_parser.add_argument(
+        "--start",
+        type=float,
+        default=None,
+        help="Optional replay start timestamp",
+    )
+
+    replay_parser.add_argument(
+        "--end",
+        type=float,
+        default=None,
+        help="Optional replay end timestamp",
+    )
+
+    replay_parser.add_argument(
+        "--speed",
+        type=float,
+        default=1.0,
+        help="Replay speed factor (default: 1.0)",
     )
 
     return parser
+
 
 def run_capture_command(args) -> None:
     can_socket = open_can_socket(args.iface)
@@ -47,14 +99,43 @@ def run_capture_command(args) -> None:
                 f"Writing to '{args.output}'. Press Ctrl+C to stop."
             )
             run_capture_loop(can_socket, file)
+
     except KeyboardInterrupt:
-        print("\n Capture stopped by user")
+        print("\nCapture stopped by user.")
     finally:
         can_socket.close()
 
-def main() -> None :
-    parser = build_parfser()
+
+def run_replay_command(args) -> None:
+    can_socket = open_can_socket(args.iface)
+
+    try:
+        print(
+            f"Starting CAN replay on interface '{args.iface}' "
+            f"from '{args.file}'. Press Ctrl+C to stop."
+        )
+
+        with open(args.file, "r", encoding="utf-8") as file:
+            replay_log(
+                can_socket=can_socket,
+                file=file,
+                id_filter=args.id_filter,
+                ts_start=args.start,
+                ts_end=args.end,
+                speed=args.speed,
+            )
+
+    except KeyboardInterrupt:
+        print("\nReplay stopped by user.")
+    finally:
+        can_socket.close()
+
+
+def main() -> None:
+    parser = build_parser()
     args = parser.parse_args()
 
     if args.command == "capture":
         run_capture_command(args)
+    elif args.command == "replay":
+        run_replay_command(args)

--- a/diagpack/logging/jsonl_logger.py
+++ b/diagpack/logging/jsonl_logger.py
@@ -1,8 +1,15 @@
 import json
 from typing import Any, TextIO
 
-
 def write_event(event: dict[str, Any], file: TextIO) -> None:
     json_line = json.dumps(event)
     file.write(json_line)
     file.write("\n")
+
+def read_events(file: TextIO):
+    for line in file:
+        line = line.strip()
+        if not line:
+            continue
+
+        yield json.loads(line) # Allow to optimize memory to give only evenement by evenements

--- a/diagpack/replay/replay_engine.py
+++ b/diagpack/replay/replay_engine.py
@@ -6,8 +6,11 @@
 """
 
 import socket
+import time
 from typing import Any
+from diagpack.replay.replay_timing import compute_delay
 from diagpack.can.socketcan import send_frame
+from diagpack.logging.jsonl_logger import read_events
 
 def event_to_frame_fields(event: dict[str, Any]) -> tuple[int, int, bytes]:
     can_id = event["id"]
@@ -19,3 +22,18 @@ def event_to_frame_fields(event: dict[str, Any]) -> tuple[int, int, bytes]:
 def replay_event(can_socket: socket.socket, event: dict[str, Any]) -> None:
     can_id, can_dlc, data = event_to_frame_fields(event)
     send_frame(can_socket, can_id, can_dlc, data)
+
+def replay_log(can_socket, file, speed: float = 1.0) -> None:
+    previous_ts = None
+
+    for event in read_events(file):
+        current_ts = event["ts"]  
+
+        if previous_ts is not None :
+            delay = compute_delay(current_ts, previous_ts, speed)
+            time.sleep(delay)
+
+        replay_event(can_socket, event)
+        previous_ts = current_ts
+    
+

--- a/diagpack/replay/replay_engine.py
+++ b/diagpack/replay/replay_engine.py
@@ -1,0 +1,21 @@
+"""
+ @file replay_engine.py
+ @brief Fournir une logique de lecture d'événements à partir d'un fichier JSONL et de les rejouer sur une interface SocketCAN
+ @copyright
+ © 2025 SYLORIA — MIT License — BAQUEY Lucas (contact@syloria.fr)
+"""
+
+import socket
+from typing import Any
+from diagpack.can.socketcan import send_frame
+
+def event_to_frame_fields(event: dict[str, Any]) -> tuple[int, int, bytes]:
+    can_id = event["id"]
+    can_dlc = event["dlc"]
+    data = bytes.fromhex(event["data"])
+    return can_id, can_dlc, data
+
+
+def replay_event(can_socket: socket.socket, event: dict[str, Any]) -> None:
+    can_id, can_dlc, data = event_to_frame_fields(event)
+    send_frame(can_socket, can_id, can_dlc, data)

--- a/diagpack/replay/replay_engine.py
+++ b/diagpack/replay/replay_engine.py
@@ -23,11 +23,28 @@ def replay_event(can_socket: socket.socket, event: dict[str, Any]) -> None:
     can_id, can_dlc, data = event_to_frame_fields(event)
     send_frame(can_socket, can_id, can_dlc, data)
 
-def replay_log(can_socket, file, speed: float = 1.0) -> None:
+
+def event_matches_filters(event: dict[str, Any], id_filter: list[int], ts_start: float, ts_end: float):
+    match_st = True
+
+    if id_filter is not None and event["id"] not in id_filter:
+        match_st = False
+    if ts_start is not None and event["ts"] < ts_start:
+        match_st = False
+    if ts_end is not None and event["ts"] > ts_end:
+        match_st = False
+    
+    return match_st
+
+def replay_log(can_socket, id_filter: list[int], ts_start: float, ts_end: float, file, speed: float = 1.0) -> None:
     previous_ts = None
 
     for event in read_events(file):
         current_ts = event["ts"]  
+        
+        # Verify that event is present in the filter
+        if event_matches_filters(event, id_filter, ts_start, ts_end) != True :
+            continue
 
         if previous_ts is not None :
             delay = compute_delay(current_ts, previous_ts, speed)

--- a/diagpack/replay/replay_timing.py
+++ b/diagpack/replay/replay_timing.py
@@ -1,0 +1,12 @@
+
+
+def compute_delay(current_ts: float, previous_ts:float, speed: float) -> float:
+    if speed <= 0:
+        raise ValueError("speed must be > 0")
+
+    delta = current_ts - previous_ts
+
+    if delta < 0:
+        return 0.0
+
+    return delta / speed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "diagpack"
+version = "0.1.0"
+description = "DiagPack CAN - diagnostic toolbox"
+authors = [{ name = "Lucas", email = "l.baquey@syloria.fr" }]
+requires-python = ">=3.10"
+
+[project.scripts]
+diagpack = "diagpack.__main__:main"


### PR DESCRIPTION
Ce PR complète le MVP replay de DiagPack CAN.

Contenu :
- lecture des événements JSONL
- calcul du timing de replay
- reconstruction et envoi des frames CAN
- moteur de replay complet
- filtres minimaux par ID et fenêtre temporelle
- connexion de la commande CLI replay

Validation :
- testé sur vcan0
- timing vérifié avec candump
- filtres ID et fenêtre temporelle validés